### PR TITLE
Corrected issue with attorney name question

### DIFF
--- a/docassemble/MATCTaxLienAnswer/data/questions/taxlien_answer.yml
+++ b/docassemble/MATCTaxLienAnswer/data/questions/taxlien_answer.yml
@@ -213,7 +213,11 @@ sets:
   - attorneys[0].name.suffix
 id: Defendant_attorney_name
 question: |
+  % if al_person_answering == "user":
+  What is your attorney's name?
+  % else:
   What is your name?
+  % endif
 fields:
   - code: |
       attorneys[0].name_fields()


### PR DESCRIPTION
Attorney name would always ask for "your name", even if the attorney wasn't the person filling out the form.

Tested locally. Will be adding Kiln tests soon, not for just copy / writing changes.