### PR TITLE
Fix auto-terms

### DIFF
--- a/docassemble/MATCTaxLienAnswer/data/questions/taxlien_answer.yml
+++ b/docassemble/MATCTaxLienAnswer/data/questions/taxlien_answer.yml
@@ -323,16 +323,15 @@ fields:
     datatype: checkboxes  
     choices: 
       - I claim the right to take back full ownership of the property by paying the amount the Court decides I owe: claims_right_to_redeem
+        help: |
+          This is known as a right to redeem the title.
       - I question the plaintiff's right to my property because of issues with the tax claim or collector's deed: questions_the_validity
+        help: |
+          This is known as questioning the validity of the plaintiff's title.
     none of the above: False 
   - "Reason(s) for questioning plaintiff's claim:": if_user_questions_validity_specify_reason
     input type: area 
     show if: users_response_to_taxlien["questions_the_validity"] 
-auto terms:
-  I claim the right to take back full ownership of the property by paying the amount the Court decides I owe: |
-    This is known as a right to redeem the title.
-  I question the plaintiff's right to my property because of issues with the tax claim or collector's deed: |
-    This is known as questioning the validity of the plaintiff's title.
 ---
 sets: 
   - property_address.address


### PR DESCRIPTION
Move specific legal definitions of the responses to the tax lien from `auto terms` (which wasn't working) to help sections on the check boxes. More useable that auto terms, and is fine for language that isn't required for SRLs to understand the main question (only lawyers, who might be looking for terms of art).

<img width="708" height="484" alt="Screenshot 2025-07-28 at 6 25 00 PM" src="https://github.com/user-attachments/assets/570e7a97-1272-4ddb-9ffc-73ee847316ea" />

Fixes #78
